### PR TITLE
Rename "bug bounty program"

### DIFF
--- a/Security (Is it safe?)/Data security/Bug bounty program
+++ b/Security (Is it safe?)/Data security/Bug bounty program
@@ -1,11 +1,11 @@
 Test Name:
-Bug bounty program
+Vulnerability disclosure program
 
 Criteria:
 The company is willing and able to address reports of vulnerabilities.
 
 Indicators:
-The company has a mechanism through which security researchers can submit vulnerabilities they discover.
+The company has a mechanism (e.g., a bug bounty) through which security researchers can submit vulnerabilities they discover.
 The company discloses the timeframe in which it will review reports of vulnerabilities.
 The company commits not to pursue legal action against security researchers.
 


### PR DESCRIPTION
"Vulnerability disclosure program" is a more generic term than "bug bounty program". Bug bounties tend to imply payment to those who report vulnerabilities. However it's more important that a vendor have a mechanism for receiving and responding to reports than it is that they offer compensation for it.