### PR TITLE
Data control: Also disclose what users *cannot* obtain, and why

### DIFF
--- a/Privacy (Is it private?)/Access and Control/Data control.yaml
+++ b/Privacy (Is it private?)/Access and Control/Data control.yaml
@@ -21,6 +21,9 @@ criterias:
 
           Disclosure of what user information users can obtain
 
+          Disclosure of what user information users are unable to obtain, and
+          justification of why that is the case.
+
 
           Users can obtain their information in a structured data format.
 


### PR DESCRIPTION
It's great that companies should have to disclose what information their
users can obtain about themselves.

If there are things the company is not willing to share with the user,
the user should be able to know about what, and make their own decision
about whether that's reasonable.