### PR TITLE
Device indicates when sensors are active

### DIFF
--- a/Privacy (Is it private?)/Overreach - Collecting Too Much Data/Data collection.yaml
+++ b/Privacy (Is it private?)/Overreach - Collecting Too Much Data/Data collection.yaml
@@ -1,11 +1,13 @@
 testName: Data collection
 criterias:
-  - criteriaName: I know what user information this company is collecting.
+  - criteriaName: I know what user information this company is collecting and when.
     indicators:
       - indicator: |-
           Disclosure of the type of user information collected
 
           Disclosure of how user information is collected
+          
+          Device gives clear indication (e.g., lit LED) when cameras and microphones are active. 
         procedures:
           - >-
             Investigation and analysis of publicly available documentation to


### PR DESCRIPTION
Device gives clear indication (e.g. lit LED) when cameras and microphones are active. Ideally allow for temporary blocking of these  devices (e.g. a sliding camera cover) when privacy assurance is desired. #48 