### PR TITLE
Update Password

### DIFF
--- a/Security (Is it safe?)/Data security/Password.yaml
+++ b/Security (Is it safe?)/Data security/Password.yaml
@@ -29,4 +29,10 @@ criterias:
           - >-
             Note if the product requires knowledge of the existing password in
             order to execute a password change.
+           
+       - indicator: Device is compatible with the use of password managers. 
+         procedures: 
+          - >- 
+            TBD
+            
 readinessFlag: '2'


### PR DESCRIPTION
Passwords managers (e.g. LastPass, OnePassword, PasswordSafe) are recognized, legitimate means for people to manage the large number of passwords required today while avoiding password reuse.

Devices should not do anything to inhibit the use of password managers. E.g. blocking the use of copying and pasting of passwords. #49 