### PR TITLE
Update Ownership

### DIFF
--- a/Ownership (Is it mine?)/Ownership/Ownership.yaml
+++ b/Ownership (Is it mine?)/Ownership/Ownership.yaml
@@ -8,7 +8,9 @@ criterias:
           purchased by the consumer.
         procedures:
           - |+
-
-
+      - indicator: >-
+          A  customer should be able to export their data from a device in a  standard format to avoid lock-in.
+        procedures:
+          - |+
 
 readinessFlag: '3'


### PR DESCRIPTION
A  customer should be able to export their data from a device in a  standard format to avoid lock-in. I'm primary thinking of what we would  consider content (e.g. photos, fitness data) but metadata could also be  considered. #50 