### PR TITLE
Resolve Issue 80 (add procedure for disclosure of security support period)

### DIFF
--- a/Security (Is it safe?)/Data security/Security over time.yaml
+++ b/Security (Is it safe?)/Data security/Security over time.yaml
@@ -5,7 +5,8 @@ criterias:
       - indicator: The product life cycle is communicated to the potential owner before purchase.
         procedures:
           - >-
-            TBD
+            Investigation and analysis of publicly available documentation to
+            determine what the company clearly discloses.
       - indicator: Software updates are authenticated.
         procedures:
           - >-


### PR DESCRIPTION
Added "Investigation and analysis of publicly available documentation to determine what the company clearly discloses" as the procedure for evaluating "The product life cycle is communicated to the potential owner before purchase."