### PR TITLE
New ToS and Privacy Policy Indicators

### DIFF
--- a/Governance & Compliance (Are they good?)/Privacy Policy & Terms of Service/Terms of Service and Privacy Policy documents.yaml
+++ b/Governance & Compliance (Are they good?)/Privacy Policy & Terms of Service/Terms of Service and Privacy Policy documents.yaml
@@ -5,7 +5,9 @@ criterias:
       service.
     indicators:
       - indicator: >-
-          The Terms of service (ToS) are easy to find.
+          The company clearly discloses which Terms of Service (ToS) apply to the product/service in question.
+      
+          The ToS are easy to find.
 
 
           The ToS are available in the language(s) most commonly spoken by the
@@ -14,9 +16,9 @@ criterias:
 
           The ToS are presented in an understandable manner.
 
-
+          The company clearly discloses which privacy policies apply to the product/service in question.
+          
           The privacy policies are easy to find.
-
 
           The privacy policies are available in the languages(s) most commonly
           spoken by the company's users.


### PR DESCRIPTION
Added "The company clearly discloses which Terms of Service (ToS) apply to the product/service in question," and " The company clearly discloses which privacy policies apply to the product/service in question."  These indicators would cover cases when a company publishes multiple terms of service and privacy policies (because it offers a range of products and services) and fails to state which terms and policies apply to which products; when a company publishes terms of service and privacy policies that seem to only apply to its website without a mention of applicability to specific products; when use of the product/service is subject to more than one terms of service and privacy policies (e.g., Snap Cash offered in Snap Chat is subject to Snap's and Square's terms of services and privacy policies) but the primary service provider does not clearly disclose it @secretrobotron @j-br0 @caseydisconnects let me know if the additions make sense.

Fixes #69