### PR TITLE
Updated with simple requirements from ISO/IEC 29147:2014

### DIFF
--- a/Security (Is it safe?)/Data security/Vulnerability disclosure program.yaml
+++ b/Security (Is it safe?)/Data security/Vulnerability disclosure program.yaml
@@ -16,6 +16,10 @@ criterias:
           The company commits not to pursue legal action against security
           researchers.
 
+          The company has a vulnerabilities@example.com or security@example.com email for recieving security or privacy concerns.
+
+          The email has an published method of recieving encrypted vulnerability reports (such as a GPG key).
+
         procedures:
           - >+
             Investigation and analysis of publicly available documentation to


### PR DESCRIPTION
There must be a way to report vulnerabilities to the company, so they need a published email. Ideally this will have a gpg key for such activities or another method of receiving secure reports.