### PR TITLE
Update Open Source.yaml

### DIFF
--- a/Governance & Compliance (Are they good?)/Open/Open Source.yaml
+++ b/Governance & Compliance (Are they good?)/Open/Open Source.yaml
@@ -1,6 +1,6 @@
 testName: Open Source
 criterias:
-  - criteriaName: The product's software is publicly available.
+  - criteriaName: The product's source code is publicly available and reusable.
     indicators:
       - indicator: Software is open source, meaning published under a license approved and listed by the Open Source Initiative. (https://opensource.org/licenses/alphabetical)
         procedures:


### PR DESCRIPTION
The wording _'the product's software is publicly available'_  does not distinguish between a binary, eg, a packaged app, and the source code used to build it (its recipe). 

For any software-only product, the software is generally 'publicly available', eg. in the App Store. 
Many proprietary hardware products even make their software/firmware publicly available from their websites.

However, a Free/Libre/Open Source product must make its recipe/source code publicly available, under a license which grants the FSF's four freedoms: 
- The freedom to run the program as you wish, for any purpose.
- The freedom to study how the program works, and change it so it does your computing as you wish. Access to the source code is a precondition for this.
- The freedom to redistribute copies so you can help your neighbor.
- The freedom to distribute copies of your modified versions to others. By doing this you can give the whole community a chance to benefit from your changes. Access to the source code is a precondition for this. 

All licenses approved by the Open Source Initiative and the Free Software Foundation grant these four freedoms.

My wording _'and reusable'_ is a simplified indication that there is more to Open Source than simply having the source code available - it must have the correct license as required by your indicator.