### PR TITLE
fix indentation error that prevented deserialization

### DIFF
--- a/Privacy (Is it private?)/Overreach - Collecting Too Much Data/Minimal data collection.yaml
+++ b/Privacy (Is it private?)/Overreach - Collecting Too Much Data/Minimal data collection.yaml
@@ -18,7 +18,7 @@ criterias:
           - >-
             Decline permissions not relevant to the product's functionality,
             verify that product is still functional.
-       - indicator: >-
+      - indicator: >-
           Manufacturer does not discriminate or other provide a lower level of
           service if a consumer exercises privacy rights or does not consent
           to unnecessary secondary data collection or use.


### PR DESCRIPTION
I couldn't deserialize this file because the parser didn't know how to handle the nonstandard whitespace.  Looks like someone just made a typo somewhere along the way...