### PR TITLE
period after etc

### DIFF
--- a/evaluations/security/best-build-practices.yaml
+++ b/evaluations/security/best-build-practices.yaml
@@ -52,7 +52,7 @@ criterias:
 
             What is the branch density?
 
-            How many stack adjusts, function calls, etc are there?
+            How many stack adjusts, function calls, etc. are there?
 
             How complex is the code?
 


### PR DESCRIPTION
Just adding a period after "etc" to keep it consistent with the other instances of etc in the Digital Standard.