### PR TITLE
'third-parties' to 'third parties'

### DIFF
--- a/evaluations/privacy/data-control.yaml
+++ b/evaluations/privacy/data-control.yaml
@@ -3,7 +3,7 @@ criterias:
   - criteriaName: I can see and control everything the company knows about me.
     indicators:
       - indicator: >-
-          The definition of 'user information' includes information collected from third-parties.
+          The definition of 'user information' includes information collected from third parties.
           
          
           Users can control the collection of their information.


### PR DESCRIPTION
No dash when "third party" is used as a noun (I googled it to be sure).